### PR TITLE
Add support for CPU number exclusion in list strings

### DIFF
--- a/list_format.go
+++ b/list_format.go
@@ -21,12 +21,18 @@ func ParseList(s string) (CPUSet, error) {
 		parts := strings.Split(elem, "-")
 		switch len(parts) {
 		case 1:
+			part, exclude := strings.CutPrefix(parts[0], "^")
+
 			var cpu uint
-			if _, err := fmt.Sscan(parts[0], &cpu); err != nil {
+			if _, err := fmt.Sscan(part, &cpu); err != nil {
 				return CPUSet{}, formatParseError(s, fmt.Sprintf("invalid element %q", elem))
 			}
 
-			cpus = append(cpus, cpu)
+			if exclude {
+				cpus = slices.DeleteFunc(cpus, func(v uint) bool { return v == cpu })
+			} else {
+				cpus = append(cpus, cpu)
+			}
 
 		case 2:
 			var lowerBound uint

--- a/list_format_test.go
+++ b/list_format_test.go
@@ -22,6 +22,11 @@ func TestParseList(t *testing.T) {
 			err:  formatParseError("a", `invalid element "a"`),
 		},
 		{
+			name: `invalid element "^"`,
+			s:    "^",
+			err:  formatParseError("^", `invalid element "^"`),
+		},
+		{
 			name: `invalid lower bound "" in range "-1"`,
 			s:    "-1",
 			err:  formatParseError("-1", `invalid lower bound "" in range "-1"`),
@@ -65,6 +70,11 @@ func TestParseList(t *testing.T) {
 			name: "bits 0, 1, 2, 7, 12, 13, and 14 set",
 			s:    "0-2,7,12-14",
 			want: Of(0, 1, 2, 7, 12, 13, 14),
+		},
+		{
+			name: "bits 1, 2, 4, and 6 set",
+			s:    "1-4,^3,6",
+			want: Of(1, 2, 4, 6),
 		},
 	} {
 		t.Run(params.name, func(t *testing.T) {


### PR DESCRIPTION
For example, the list string "1-4,^3,6" represents the following cpuset: 1,2,4,6.

Closes #7