### PR TITLE
Release 0.2.2

### DIFF
--- a/list_format_test.go
+++ b/list_format_test.go
@@ -17,14 +17,19 @@ func TestParseList(t *testing.T) {
 			err:  formatParseError(",", `invalid element ""`),
 		},
 		{
+			name: `invalid element "^"`,
+			s:    "^",
+			err:  formatParseError("^", `invalid element "^"`),
+		},
+		{
 			name: `invalid element "a"`,
 			s:    "a",
 			err:  formatParseError("a", `invalid element "a"`),
 		},
 		{
-			name: `invalid element "^"`,
-			s:    "^",
-			err:  formatParseError("^", `invalid element "^"`),
+			name: `invalid element "0a"`,
+			s:    "0a",
+			err:  formatParseError("0a", `invalid element "0a"`),
 		},
 		{
 			name: `invalid lower bound "" in range "-1"`,
@@ -37,14 +42,24 @@ func TestParseList(t *testing.T) {
 			err:  formatParseError("a-1", `invalid lower bound "a" in range "a-1"`),
 		},
 		{
-			name: `invalid upper bound "" in range "1-"`,
-			s:    "1-",
-			err:  formatParseError("1-", `invalid upper bound "" in range "1-"`),
+			name: `invalid lower bound "0a" in range "0a-1"`,
+			s:    "0a-1",
+			err:  formatParseError("0a-1", `invalid lower bound "0a" in range "0a-1"`),
 		},
 		{
-			name: `invalid upper bound "b" in range "1-b"`,
-			s:    "1-b",
-			err:  formatParseError("1-b", `invalid upper bound "b" in range "1-b"`),
+			name: `invalid upper bound "" in range "0-"`,
+			s:    "0-",
+			err:  formatParseError("0-", `invalid upper bound "" in range "0-"`),
+		},
+		{
+			name: `invalid upper bound "b" in range "0-b"`,
+			s:    "0-b",
+			err:  formatParseError("0-b", `invalid upper bound "b" in range "0-b"`),
+		},
+		{
+			name: `invalid upper bound "1b" in range "0-1b"`,
+			s:    "0-1b",
+			err:  formatParseError("0-1b", `invalid upper bound "1b" in range "0-1b"`),
 		},
 		{
 			name: `negative range "1-0"`,

--- a/mask_format_test.go
+++ b/mask_format_test.go
@@ -27,6 +27,11 @@ func TestParseMask(t *testing.T) {
 			err:  formatParseError("xxxxxxxx", `invalid 32-bit word "xxxxxxxx"`),
 		},
 		{
+			name: `invalid 32-bit word "1"`,
+			s:    "1",
+			err:  formatParseError("1", `invalid 32-bit word "1"`),
+		},
+		{
 			name: "no bit set",
 			s:    "",
 			want: CPUSet{},

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package cpuset
 
-const Version = "0.2.1"
+const Version = "0.2.2"


### PR DESCRIPTION
**Bug fixes:**

- **formats:** use of fmt.Sscan allows successful parsing of invalid strings (#16)