### PR TITLE
Unsigned integer overflow when parsing long mask strings

### DIFF
--- a/list_format.go
+++ b/list_format.go
@@ -59,7 +59,7 @@ func ParseList(s string) (cset CPUSet, _ error) {
 			}
 
 			for i := range upperBound - lowerBound + 1 {
-				cset.Add(uint(lowerBound + i))
+				cset.Add(lowerBound + i)
 			}
 
 		default:

--- a/mask_format_test.go
+++ b/mask_format_test.go
@@ -27,11 +27,6 @@ func TestParseMask(t *testing.T) {
 			err:  formatParseError("xxxxxxxx", `invalid 32-bit word "xxxxxxxx"`),
 		},
 		{
-			name: `invalid 32-bit word "1"`,
-			s:    "1",
-			err:  formatParseError("1", `invalid 32-bit word "1"`),
-		},
-		{
 			name: "no bit set",
 			s:    "",
 			want: CPUSet{},


### PR DESCRIPTION
Long mask strings make the offset variable overflow during parsing.

Closes #19