### PR TITLE
Release 0.2.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: Lint, test and release
 on: push
 
 env:
-  DEVBOX_USE_VERSION: '0.14.0'
+  DEVBOX_USE_VERSION: '0.14.2'
 
 jobs:
   lint-test:

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.2/.schema/devbox.schema.json",
   "packages": [
-    "go@1.23.7",
+    "go@1.23.9",
     "bats@1.11.1",
     "goreleaser@2.8.0",
     "golangci-lint@1.64.7",

--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,7 @@
   "packages": [
     "go@1.23.9",
     "bats@1.11.1",
-    "goreleaser@2.8.0",
+    "goreleaser@2.9.0",
     "golangci-lint@1.64.7",
     "shellcheck@0.10.0"
   ],

--- a/devbox.json
+++ b/devbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.0/.schema/devbox.schema.json",
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.2/.schema/devbox.schema.json",
   "packages": [
     "go@1.23.7",
     "bats@1.11.1",

--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,7 @@
     "go@1.23.9",
     "bats@1.11.1",
     "goreleaser@2.9.0",
-    "golangci-lint@1.64.7",
+    "golangci-lint@1.64.8",
     "shellcheck@0.10.0"
   ],
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,8 +2,8 @@
   "lockfile_version": "1",
   "packages": {
     "bats@1.11.1": {
-      "last_modified": "2025-03-13T11:38:39Z",
-      "resolved": "github:NixOS/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a#bats",
+      "last_modified": "2025-05-19T23:16:24Z",
+      "resolved": "github:NixOS/nixpkgs/359c442b7d1f6229c1dc978116d32d6c07fe8440#bats",
       "source": "devbox-search",
       "version": "1.11.1",
       "systems": {
@@ -11,46 +11,47 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/xiqw78c7byr3k987al1gxwxrxjcyf9kr-bats-1.11.1",
+              "path": "/nix/store/ffaqbcz3lx4hv70cpl3zw8905asf0wk0-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/xiqw78c7byr3k987al1gxwxrxjcyf9kr-bats-1.11.1"
+          "store_path": "/nix/store/ffaqbcz3lx4hv70cpl3zw8905asf0wk0-bats-1.11.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/xcyw4lvz8ckdbzba2hd0hh1hl0vn0pvk-bats-1.11.1",
+              "path": "/nix/store/rmrd2ix70l5dfyl8y0fqlc81577k16mh-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/xcyw4lvz8ckdbzba2hd0hh1hl0vn0pvk-bats-1.11.1"
+          "store_path": "/nix/store/rmrd2ix70l5dfyl8y0fqlc81577k16mh-bats-1.11.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/dgjphsc85byp8s89y7jacfclk331pz95-bats-1.11.1",
+              "path": "/nix/store/dshgcgrx60nwam2wcmnbfq597vcp6j68-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/dgjphsc85byp8s89y7jacfclk331pz95-bats-1.11.1"
+          "store_path": "/nix/store/dshgcgrx60nwam2wcmnbfq597vcp6j68-bats-1.11.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ipw9sbca8a7cljrzl4agq0prsjdlj8vr-bats-1.11.1",
+              "path": "/nix/store/pfm41aj6rik9223yd28g4z5vb0d6pkzk-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ipw9sbca8a7cljrzl4agq0prsjdlj8vr-bats-1.11.1"
+          "store_path": "/nix/store/pfm41aj6rik9223yd28g4z5vb0d6pkzk-bats-1.11.1"
         }
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/3549532663732bfd89993204d40543e9edaec4f2?lastModified=1742272065&narHash=sha256-ud8vcSzJsZ%2FCK%2Br8%2Fv0lyf4yUntVmDq6Z0A41ODfWbE%3D"
+      "last_modified": "2025-06-06T12:35:49Z",
+      "resolved": "github:NixOS/nixpkgs/a4ff0e3c64846abea89662bfbacf037ef4b34207?lastModified=1749213349&narHash=sha256-UAaWOyQhdp7nXzsbmLVC67fo%2BQetzoTm9hsPf9X3yr4%3D"
     },
     "go@1.23.7": {
       "last_modified": "2025-03-11T17:52:14Z",
@@ -82,11 +83,11 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/mcajc7fgnbyzq4845sk4m3h6gc99vzzc-go-1.23.7",
+              "path": "/nix/store/b41fh5a662df54az1jw6qgqsyw8frdhq-go-1.23.7",
               "default": true
             }
           ],
-          "store_path": "/nix/store/mcajc7fgnbyzq4845sk4m3h6gc99vzzc-go-1.23.7"
+          "store_path": "/nix/store/b41fh5a662df54az1jw6qgqsyw8frdhq-go-1.23.7"
         },
         "x86_64-linux": {
           "outputs": [
@@ -197,8 +198,8 @@
       }
     },
     "shellcheck@0.10.0": {
-      "last_modified": "2025-02-23T09:42:26Z",
-      "resolved": "github:NixOS/nixpkgs/2d068ae5c6516b2d04562de50a58c682540de9bf#shellcheck",
+      "last_modified": "2025-05-16T20:19:48Z",
+      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#shellcheck",
       "source": "devbox-search",
       "version": "0.10.0",
       "systems": {
@@ -206,97 +207,97 @@
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/325gxaqj2jf8is7bl9l76xrg4lshm72f-shellcheck-0.10.0-bin",
+              "path": "/nix/store/4l7lf05gw9l0l84sssaxkwqb6arkx652-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/g62azyf0p9xj0d9j90dr7yhasbdnm7dk-shellcheck-0.10.0-man",
+              "path": "/nix/store/f0fscjx6xa6kbczhav1bh0vq3w2pmwfn-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/rjln13sbb4g1i6izlymwdj0ns5mlkdk9-shellcheck-0.10.0-doc",
+              "path": "/nix/store/mwahkil7jkc2y4y0q3myrkicp366vb82-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/ch4cq7jdr08fm5anfwj9jr559v8lq5i2-shellcheck-0.10.0"
+              "path": "/nix/store/fbj9729m17pdvlinsdqxnd8ddl4iirzm-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/325gxaqj2jf8is7bl9l76xrg4lshm72f-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/4l7lf05gw9l0l84sssaxkwqb6arkx652-shellcheck-0.10.0-bin"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/yb6v9wm9d42xdgjw7s2vn4iv0p0qvd05-shellcheck-0.10.0-bin",
+              "path": "/nix/store/irlalbizkr3bn83g1drmi4p4h4dx16i6-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/q7fiw7hvhmnirv6c925sscwc4984rwf3-shellcheck-0.10.0-man",
+              "path": "/nix/store/zfpypv8l8py55rifk9yhzcis13z4sc5k-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/hk2vyk916nadycvfwa1m1y70lrh218jl-shellcheck-0.10.0-doc",
+              "path": "/nix/store/c3s6fpb28bfm02vbpi9cvxpxyymzmx9n-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/7jm454lj1y0cy90a843wj82ywr5fxmg5-shellcheck-0.10.0"
+              "path": "/nix/store/6lgybvih5m2qinh419qzn52q6k4fwf4m-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/yb6v9wm9d42xdgjw7s2vn4iv0p0qvd05-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/irlalbizkr3bn83g1drmi4p4h4dx16i6-shellcheck-0.10.0-bin"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/k17i8v7crc5hv7lzi490hjg40rc1xmvz-shellcheck-0.10.0-bin",
+              "path": "/nix/store/z8v7j4xkwswrx5vc05cfn9yp9sbxfkd2-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/cim6ifqys4d38wqx71gkiw9s7wm3m0vh-shellcheck-0.10.0-man",
+              "path": "/nix/store/q88aiz7agllcjb8zflwlh23fm2wh431f-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/hc649lnlbbwzy50kg81ib3h0bwadv70w-shellcheck-0.10.0-doc",
+              "path": "/nix/store/df107d185wg9kqc03aaq1fcyl2bknjnc-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/vxih59dn7w40cny8v5r28ca5g8kmahvl-shellcheck-0.10.0"
+              "path": "/nix/store/wz9qinlsaghahhj2bvlva9lgz3d8g07s-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/k17i8v7crc5hv7lzi490hjg40rc1xmvz-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/z8v7j4xkwswrx5vc05cfn9yp9sbxfkd2-shellcheck-0.10.0-bin"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/zpsn5p7h5bkp6x8dwvlipgrqp9y57q7r-shellcheck-0.10.0-bin",
+              "path": "/nix/store/dw5aa0sf40aahg0fbwgfjwhjxnnrmipl-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/div4481mhzjf4278aqv6bv3zcd0ms9q7-shellcheck-0.10.0-man",
+              "path": "/nix/store/6ksvcjrdzxn89ql0059g2hs0nmw0rf5v-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/nncljxvssag7w1krwbsl0yf8csvdy3y5-shellcheck-0.10.0-doc",
+              "path": "/nix/store/mfn1kxg9asp4nq4yrcr3niz5kfddaisf-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/7rs2gic77z9hjp5ssxf4vlwfqxq4qww6-shellcheck-0.10.0"
+              "path": "/nix/store/gxzk021q0f0h0jqwxiqikl1gkiih7qiq-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/zpsn5p7h5bkp6x8dwvlipgrqp9y57q7r-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/dw5aa0sf40aahg0fbwgfjwhjxnnrmipl-shellcheck-0.10.0-bin"
         }
       }
     }

--- a/devbox.lock
+++ b/devbox.lock
@@ -53,51 +53,51 @@
       "last_modified": "2025-06-06T12:35:49Z",
       "resolved": "github:NixOS/nixpkgs/a4ff0e3c64846abea89662bfbacf037ef4b34207?lastModified=1749213349&narHash=sha256-UAaWOyQhdp7nXzsbmLVC67fo%2BQetzoTm9hsPf9X3yr4%3D"
     },
-    "go@1.23.7": {
-      "last_modified": "2025-03-11T17:52:14Z",
-      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#go_1_23",
+    "go@1.23.9": {
+      "last_modified": "2025-05-16T20:19:48Z",
+      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#go_1_23",
       "source": "devbox-search",
-      "version": "1.23.7",
+      "version": "1.23.9",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/pmgial79wq49zriy1y6dc19qdrjqyv8g-go-1.23.7",
+              "path": "/nix/store/q8qj75chj5s366bmkiyd99gf7hnxh106-go-1.23.9",
               "default": true
             }
           ],
-          "store_path": "/nix/store/pmgial79wq49zriy1y6dc19qdrjqyv8g-go-1.23.7"
+          "store_path": "/nix/store/q8qj75chj5s366bmkiyd99gf7hnxh106-go-1.23.9"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/qlklf8pp44ykx63xaryj6apbnw036rm9-go-1.23.7",
+              "path": "/nix/store/81cbh4rdnyk7mf46a66z2dgkr7nfg4jg-go-1.23.9",
               "default": true
             }
           ],
-          "store_path": "/nix/store/qlklf8pp44ykx63xaryj6apbnw036rm9-go-1.23.7"
+          "store_path": "/nix/store/81cbh4rdnyk7mf46a66z2dgkr7nfg4jg-go-1.23.9"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/b41fh5a662df54az1jw6qgqsyw8frdhq-go-1.23.7",
+              "path": "/nix/store/hdy31n0wzq37an87v9p51xvl5rnlrkpk-go-1.23.9",
               "default": true
             }
           ],
-          "store_path": "/nix/store/b41fh5a662df54az1jw6qgqsyw8frdhq-go-1.23.7"
+          "store_path": "/nix/store/hdy31n0wzq37an87v9p51xvl5rnlrkpk-go-1.23.9"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/valwknmr0qzxq70h4ijm9w1jvgc3grsp-go-1.23.7",
+              "path": "/nix/store/fd7c2wlqwdzz3x0amhaairhhd2j2vl0s-go-1.23.9",
               "default": true
             }
           ],
-          "store_path": "/nix/store/valwknmr0qzxq70h4ijm9w1jvgc3grsp-go-1.23.7"
+          "store_path": "/nix/store/fd7c2wlqwdzz3x0amhaairhhd2j2vl0s-go-1.23.9"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -149,51 +149,51 @@
         }
       }
     },
-    "goreleaser@2.8.0": {
-      "last_modified": "2025-03-16T16:17:41Z",
-      "resolved": "github:NixOS/nixpkgs/8f76cf16b17c51ae0cc8e55488069593f6dab645#goreleaser",
+    "goreleaser@2.9.0": {
+      "last_modified": "2025-05-16T20:19:48Z",
+      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#goreleaser",
       "source": "devbox-search",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/r8gkyn9gvzdw1bxhas05qipx3cvjvb5k-goreleaser-2.8.0",
+              "path": "/nix/store/lqihz0f2h9zjqlhk74cayb9l74zgkxj2-goreleaser-2.9.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/r8gkyn9gvzdw1bxhas05qipx3cvjvb5k-goreleaser-2.8.0"
+          "store_path": "/nix/store/lqihz0f2h9zjqlhk74cayb9l74zgkxj2-goreleaser-2.9.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/sssbsl74vxy8bnyn3k93fcx10q9zxrxr-goreleaser-2.8.0",
+              "path": "/nix/store/wg1ndxx3hq7lcxg0nkzgs3myrflr5jm0-goreleaser-2.9.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/sssbsl74vxy8bnyn3k93fcx10q9zxrxr-goreleaser-2.8.0"
+          "store_path": "/nix/store/wg1ndxx3hq7lcxg0nkzgs3myrflr5jm0-goreleaser-2.9.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/mc6998ik7d8riygr5lpwcwj22rqviadw-goreleaser-2.8.0",
+              "path": "/nix/store/v17lq7ap19pajdhp04n4b7p4y5f2mxrr-goreleaser-2.9.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/mc6998ik7d8riygr5lpwcwj22rqviadw-goreleaser-2.8.0"
+          "store_path": "/nix/store/v17lq7ap19pajdhp04n4b7p4y5f2mxrr-goreleaser-2.9.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ag1ca4kgj4mzclfcyr8zg9n2pk03b5wr-goreleaser-2.8.0",
+              "path": "/nix/store/rvjwgy6zz5qwipcm709jvf3j38r552nw-goreleaser-2.9.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ag1ca4kgj4mzclfcyr8zg9n2pk03b5wr-goreleaser-2.8.0"
+          "store_path": "/nix/store/rvjwgy6zz5qwipcm709jvf3j38r552nw-goreleaser-2.9.0"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -101,51 +101,51 @@
         }
       }
     },
-    "golangci-lint@1.64.7": {
-      "last_modified": "2025-03-16T16:17:41Z",
-      "resolved": "github:NixOS/nixpkgs/8f76cf16b17c51ae0cc8e55488069593f6dab645#golangci-lint",
+    "golangci-lint@1.64.8": {
+      "last_modified": "2025-03-23T14:04:58Z",
+      "resolved": "github:NixOS/nixpkgs/f3a2a0601e9669a6e38af25b46ce6c4563bcb6da#golangci-lint",
       "source": "devbox-search",
-      "version": "1.64.7",
+      "version": "1.64.8",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/34x05rpqww3l30wfnx2c5lg2j79kfjjw-golangci-lint-1.64.7",
+              "path": "/nix/store/8142ildg0bp11j0ssdc77il5rxv25sm8-golangci-lint-1.64.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/34x05rpqww3l30wfnx2c5lg2j79kfjjw-golangci-lint-1.64.7"
+          "store_path": "/nix/store/8142ildg0bp11j0ssdc77il5rxv25sm8-golangci-lint-1.64.8"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/bgqlln3xcjb5nxvvygd7ss7xmwyd3wqa-golangci-lint-1.64.7",
+              "path": "/nix/store/pl31v3jjbrf8l0ll7xg40dw3s2xgxbaa-golangci-lint-1.64.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/bgqlln3xcjb5nxvvygd7ss7xmwyd3wqa-golangci-lint-1.64.7"
+          "store_path": "/nix/store/pl31v3jjbrf8l0ll7xg40dw3s2xgxbaa-golangci-lint-1.64.8"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/hff316fcclip9cwdjppcakx5fy83v7sj-golangci-lint-1.64.7",
+              "path": "/nix/store/0lz3b95c0y9mh95dl0jyiyn76fjxq3yf-golangci-lint-1.64.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/hff316fcclip9cwdjppcakx5fy83v7sj-golangci-lint-1.64.7"
+          "store_path": "/nix/store/0lz3b95c0y9mh95dl0jyiyn76fjxq3yf-golangci-lint-1.64.8"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/vdq0ixi31wm5ypfv2wbpn5p95ahr9cf8-golangci-lint-1.64.7",
+              "path": "/nix/store/9xz2x85fpbblk2mpwj54azimxx4cvkb1-golangci-lint-1.64.8",
               "default": true
             }
           ],
-          "store_path": "/nix/store/vdq0ixi31wm5ypfv2wbpn5p95ahr9cf8-golangci-lint-1.64.7"
+          "store_path": "/nix/store/9xz2x85fpbblk2mpwj54azimxx4cvkb1-golangci-lint-1.64.8"
         }
       }
     },

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package cpuset
 
-const Version = "0.2.3"
+const Version = "0.2.4"


### PR DESCRIPTION
**Chores:**

- **deps:** bump devbox from 0.14.0 to 0.14.2 (#26)
- **deps:** bump go from 1.23.7 to 1.23.9 (#26)
- **deps:** bump goreleaser from 2.8.0 to 2.9.0 (#26)
- **deps:** bump golangci-lint from 1.64.7 to 1.64.8 (#26)