### PR TITLE
Release 0.3.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: Lint, test and release
 on: push
 
 env:
-  DEVBOX_USE_VERSION: '0.14.2'
+  DEVBOX_USE_VERSION: '0.16.0'
 
 jobs:
   lint-test:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,8 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
+  enable:
+    - govet
+formatters:
   enable:
     - gofmt
-    - govet

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,5 @@
 version: 2
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - id: cpuset
     main: ./cmd/cpuset

--- a/devbox.json
+++ b/devbox.json
@@ -5,14 +5,14 @@
     "bats@1.12.0",
     "goreleaser@2.13.0",
     "golangci-lint@2.6.2",
-    "shellcheck@0.10.0"
+    "shellcheck-minimal@0.11.0"
   ],
   "shell": {
     "init_hook": [],
     "scripts": {
       "lint": [
         "golangci-lint run ./...",
-        "git ls-files '*.bats' '*.sh' | xargs shellcheck"
+        "shellcheck ./cmd/cpuset/main_test.bats"
       ],
       "test": [
         "go test -v ./...",

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
   "packages": [
-    "go@1.23.9",
+    "go@1.24.11",
     "bats@1.11.1",
     "goreleaser@2.9.0",
     "golangci-lint@1.64.8",

--- a/devbox.json
+++ b/devbox.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
   "packages": [
     "go@1.24.11",
-    "bats@1.11.1",
+    "bats@1.12.0",
     "goreleaser@2.13.0",
     "golangci-lint@2.6.2",
     "shellcheck@0.10.0"

--- a/devbox.json
+++ b/devbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.2/.schema/devbox.schema.json",
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.16.0/.schema/devbox.schema.json",
   "packages": [
     "go@1.23.9",
     "bats@1.11.1",

--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,7 @@
   "packages": [
     "go@1.24.11",
     "bats@1.11.1",
-    "goreleaser@2.9.0",
+    "goreleaser@2.13.0",
     "golangci-lint@1.64.8",
     "shellcheck@0.10.0"
   ],

--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,7 @@
     "go@1.24.11",
     "bats@1.11.1",
     "goreleaser@2.13.0",
-    "golangci-lint@1.64.8",
+    "golangci-lint@2.6.2",
     "shellcheck@0.10.0"
   ],
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -101,51 +101,51 @@
         }
       }
     },
-    "golangci-lint@1.64.8": {
-      "last_modified": "2025-03-23T14:04:58Z",
-      "resolved": "github:NixOS/nixpkgs/f3a2a0601e9669a6e38af25b46ce6c4563bcb6da#golangci-lint",
+    "golangci-lint@2.6.2": {
+      "last_modified": "2025-11-23T21:50:36Z",
+      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#golangci-lint",
       "source": "devbox-search",
-      "version": "1.64.8",
+      "version": "2.6.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/8142ildg0bp11j0ssdc77il5rxv25sm8-golangci-lint-1.64.8",
+              "path": "/nix/store/yvnfabxmnwmig8ralc22has0kpk7gbkn-golangci-lint-2.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/8142ildg0bp11j0ssdc77il5rxv25sm8-golangci-lint-1.64.8"
+          "store_path": "/nix/store/yvnfabxmnwmig8ralc22has0kpk7gbkn-golangci-lint-2.6.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/pl31v3jjbrf8l0ll7xg40dw3s2xgxbaa-golangci-lint-1.64.8",
+              "path": "/nix/store/jfhvpym9967m3rf8shlcmlarfbf73cpj-golangci-lint-2.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/pl31v3jjbrf8l0ll7xg40dw3s2xgxbaa-golangci-lint-1.64.8"
+          "store_path": "/nix/store/jfhvpym9967m3rf8shlcmlarfbf73cpj-golangci-lint-2.6.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/0lz3b95c0y9mh95dl0jyiyn76fjxq3yf-golangci-lint-1.64.8",
+              "path": "/nix/store/bg84ksi4vm63c7m39yj6y1ga9n64n3mp-golangci-lint-2.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/0lz3b95c0y9mh95dl0jyiyn76fjxq3yf-golangci-lint-1.64.8"
+          "store_path": "/nix/store/bg84ksi4vm63c7m39yj6y1ga9n64n3mp-golangci-lint-2.6.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9xz2x85fpbblk2mpwj54azimxx4cvkb1-golangci-lint-1.64.8",
+              "path": "/nix/store/3kn873p4cpk0yhz7y0qvwpnn1h885a40-golangci-lint-2.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/9xz2x85fpbblk2mpwj54azimxx4cvkb1-golangci-lint-1.64.8"
+          "store_path": "/nix/store/3kn873p4cpk0yhz7y0qvwpnn1h885a40-golangci-lint-2.6.2"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -149,51 +149,51 @@
         }
       }
     },
-    "goreleaser@2.9.0": {
-      "last_modified": "2025-05-16T20:19:48Z",
-      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#goreleaser",
+    "goreleaser@2.13.0": {
+      "last_modified": "2025-12-01T02:47:39Z",
+      "resolved": "github:NixOS/nixpkgs/0d70460758949966e91d9ecb823b821f963cefbb#goreleaser",
       "source": "devbox-search",
-      "version": "2.9.0",
+      "version": "2.13.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/lqihz0f2h9zjqlhk74cayb9l74zgkxj2-goreleaser-2.9.0",
+              "path": "/nix/store/qb8wnpyspm683qway34y29n0zvad4q55-goreleaser-2.13.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/lqihz0f2h9zjqlhk74cayb9l74zgkxj2-goreleaser-2.9.0"
+          "store_path": "/nix/store/qb8wnpyspm683qway34y29n0zvad4q55-goreleaser-2.13.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/wg1ndxx3hq7lcxg0nkzgs3myrflr5jm0-goreleaser-2.9.0",
+              "path": "/nix/store/0sgsy09mlwgsd3yr479lcv5mxp8k22pj-goreleaser-2.13.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/wg1ndxx3hq7lcxg0nkzgs3myrflr5jm0-goreleaser-2.9.0"
+          "store_path": "/nix/store/0sgsy09mlwgsd3yr479lcv5mxp8k22pj-goreleaser-2.13.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/v17lq7ap19pajdhp04n4b7p4y5f2mxrr-goreleaser-2.9.0",
+              "path": "/nix/store/zksrax3g8qaaycl66kcbxjkcx2262i7j-goreleaser-2.13.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/v17lq7ap19pajdhp04n4b7p4y5f2mxrr-goreleaser-2.9.0"
+          "store_path": "/nix/store/zksrax3g8qaaycl66kcbxjkcx2262i7j-goreleaser-2.13.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rvjwgy6zz5qwipcm709jvf3j38r552nw-goreleaser-2.9.0",
+              "path": "/nix/store/s0j5i8m7xlnh403la8d60y19wm8csxq3-goreleaser-2.13.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/rvjwgy6zz5qwipcm709jvf3j38r552nw-goreleaser-2.9.0"
+          "store_path": "/nix/store/s0j5i8m7xlnh403la8d60y19wm8csxq3-goreleaser-2.13.0"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -53,51 +53,51 @@
       "last_modified": "2025-12-05T15:03:55Z",
       "resolved": "github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069?lastModified=1764947035&narHash=sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx%2BJ2FfutM7T9w%3D"
     },
-    "go@1.23.9": {
-      "last_modified": "2025-05-16T20:19:48Z",
-      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#go_1_23",
+    "go@1.24.11": {
+      "last_modified": "2025-12-03T03:51:48Z",
+      "resolved": "github:NixOS/nixpkgs/cadcc8de247676e4751c9d4a935acb2c0b059113#go_1_24",
       "source": "devbox-search",
-      "version": "1.23.9",
+      "version": "1.24.11",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/q8qj75chj5s366bmkiyd99gf7hnxh106-go-1.23.9",
+              "path": "/nix/store/8k6qc3a84qvq9k85d7szjrknb91baqza-go-1.24.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/q8qj75chj5s366bmkiyd99gf7hnxh106-go-1.23.9"
+          "store_path": "/nix/store/8k6qc3a84qvq9k85d7szjrknb91baqza-go-1.24.11"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/81cbh4rdnyk7mf46a66z2dgkr7nfg4jg-go-1.23.9",
+              "path": "/nix/store/qnfbvhrv4nv8rij76fp4pw6wjijc9dwh-go-1.24.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/81cbh4rdnyk7mf46a66z2dgkr7nfg4jg-go-1.23.9"
+          "store_path": "/nix/store/qnfbvhrv4nv8rij76fp4pw6wjijc9dwh-go-1.24.11"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/hdy31n0wzq37an87v9p51xvl5rnlrkpk-go-1.23.9",
+              "path": "/nix/store/cisrkjr39cdgwyc42r1348ly04jahh9d-go-1.24.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/hdy31n0wzq37an87v9p51xvl5rnlrkpk-go-1.23.9"
+          "store_path": "/nix/store/cisrkjr39cdgwyc42r1348ly04jahh9d-go-1.24.11"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/fd7c2wlqwdzz3x0amhaairhhd2j2vl0s-go-1.23.9",
+              "path": "/nix/store/i2yqx3x40i64g0mcb2ray2rxvz1zwbhm-go-1.24.11",
               "default": true
             }
           ],
-          "store_path": "/nix/store/fd7c2wlqwdzz3x0amhaairhhd2j2vl0s-go-1.23.9"
+          "store_path": "/nix/store/i2yqx3x40i64g0mcb2ray2rxvz1zwbhm-go-1.24.11"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -197,107 +197,51 @@
         }
       }
     },
-    "shellcheck@0.10.0": {
-      "last_modified": "2025-09-18T16:33:27Z",
-      "resolved": "github:NixOS/nixpkgs/f4b140d5b253f5e2a1ff4e5506edbf8267724bde#shellcheck",
+    "shellcheck-minimal@0.11.0": {
+      "last_modified": "2025-11-23T21:50:36Z",
+      "resolved": "github:NixOS/nixpkgs/ee09932cedcef15aaf476f9343d1dea2cb77e261#shellcheck-minimal",
       "source": "devbox-search",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
-              "name": "bin",
-              "path": "/nix/store/dxppq6y4mb663r0li716pavrahwh9sws-shellcheck-0.10.0-bin",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/7lpymai82rrcps6z7zl4q5j69w3pp5ng-shellcheck-0.10.0-man",
-              "default": true
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/0wbb09lk7bx9ywc453a8nnw41hc8qp1i-shellcheck-0.10.0-doc",
-              "default": true
-            },
-            {
               "name": "out",
-              "path": "/nix/store/ffxba7sh87j0vg759cjm7qmcadsmbfw7-shellcheck-0.10.0"
+              "path": "/nix/store/2d17nz4fjdpdhqxsnigy923bq9l4rnzm-ShellCheck-0.11.0",
+              "default": true
             }
           ],
-          "store_path": "/nix/store/dxppq6y4mb663r0li716pavrahwh9sws-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/2d17nz4fjdpdhqxsnigy923bq9l4rnzm-ShellCheck-0.11.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
-              "name": "bin",
-              "path": "/nix/store/kvhcnjzmjyqc641yd57f7g26nraw64sm-shellcheck-0.10.0-bin",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/2ps0gaalsjfvd6vh0zhq2l4d6xgrma8l-shellcheck-0.10.0-man",
-              "default": true
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/vn7d2fwlkjgq6hy3c7gjcypg3slkf592-shellcheck-0.10.0-doc",
-              "default": true
-            },
-            {
               "name": "out",
-              "path": "/nix/store/dxqnpdj372kh001d84dg29l6l3aflrc0-shellcheck-0.10.0"
+              "path": "/nix/store/jwn1wd1811g6zfd0krbz53s01848848j-ShellCheck-0.11.0",
+              "default": true
             }
           ],
-          "store_path": "/nix/store/kvhcnjzmjyqc641yd57f7g26nraw64sm-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/jwn1wd1811g6zfd0krbz53s01848848j-ShellCheck-0.11.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
-              "name": "bin",
-              "path": "/nix/store/ri8byd60sb58xqf3m0bli53xflx9n4l4-shellcheck-0.10.0-bin",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/0an459l9ajzapm9kinqh344xnlzp70fy-shellcheck-0.10.0-man",
-              "default": true
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/b1hcrb9c98w7cwqjc5wy5rrfx1gnw7lz-shellcheck-0.10.0-doc",
-              "default": true
-            },
-            {
               "name": "out",
-              "path": "/nix/store/5rfsd78v2il52xqvxmx15pp52zlds4al-shellcheck-0.10.0"
+              "path": "/nix/store/32yjarxbv4sm69vrwzwk3gdvnb2z9dyx-ShellCheck-0.11.0",
+              "default": true
             }
           ],
-          "store_path": "/nix/store/ri8byd60sb58xqf3m0bli53xflx9n4l4-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/32yjarxbv4sm69vrwzwk3gdvnb2z9dyx-ShellCheck-0.11.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
-              "name": "bin",
-              "path": "/nix/store/ayfrkdpk1sygzwwjqh19gcp5sfh557zd-shellcheck-0.10.0-bin",
-              "default": true
-            },
-            {
-              "name": "man",
-              "path": "/nix/store/n8asflghb73ph65f2ixvr8hv6h7v9w0g-shellcheck-0.10.0-man",
-              "default": true
-            },
-            {
-              "name": "doc",
-              "path": "/nix/store/wgb75fahwjf0h5gc7ww5zcvkhbm88sps-shellcheck-0.10.0-doc",
-              "default": true
-            },
-            {
               "name": "out",
-              "path": "/nix/store/vh0ng4iyxch4lqmjmkbbjx8dw8xp569y-shellcheck-0.10.0"
+              "path": "/nix/store/b71g29x4vc7a7vvzrhsd6rqr5v2rylna-ShellCheck-0.11.0",
+              "default": true
             }
           ],
-          "store_path": "/nix/store/ayfrkdpk1sygzwwjqh19gcp5sfh557zd-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/b71g29x4vc7a7vvzrhsd6rqr5v2rylna-ShellCheck-0.11.0"
         }
       }
     }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,51 +1,51 @@
 {
   "lockfile_version": "1",
   "packages": {
-    "bats@1.11.1": {
-      "last_modified": "2025-06-20T02:24:11Z",
-      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#bats",
+    "bats@1.12.0": {
+      "last_modified": "2025-11-25T14:41:04Z",
+      "resolved": "github:NixOS/nixpkgs/dc205f7b4fdb04c8b7877b43edb7b73be7730081#bats",
       "source": "devbox-search",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/whjif7jimfg5kzydsjr80r4a3xwrvzl8-bats-1.11.1",
+              "path": "/nix/store/gfqwb6ransgiq41lbihm6fwqd7rbncnb-bats-1.12.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/whjif7jimfg5kzydsjr80r4a3xwrvzl8-bats-1.11.1"
+          "store_path": "/nix/store/gfqwb6ransgiq41lbihm6fwqd7rbncnb-bats-1.12.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/sga64j8wgf0wwpn1xggr2hc0ijsgyvlk-bats-1.11.1",
+              "path": "/nix/store/5cm59dnnfqhgvgn9ar1z4519hg9pczl0-bats-1.12.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/sga64j8wgf0wwpn1xggr2hc0ijsgyvlk-bats-1.11.1"
+          "store_path": "/nix/store/5cm59dnnfqhgvgn9ar1z4519hg9pczl0-bats-1.12.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/07h34ynvlcryaqcg4bjdgcs6qjd1f1py-bats-1.11.1",
+              "path": "/nix/store/0fnghy1l5vzrishx9gv39qsifhx6qj7b-bats-1.12.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/07h34ynvlcryaqcg4bjdgcs6qjd1f1py-bats-1.11.1"
+          "store_path": "/nix/store/0fnghy1l5vzrishx9gv39qsifhx6qj7b-bats-1.12.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/az8pn6fcgrf8lv7kv7jdjyghbfn9z15r-bats-1.11.1",
+              "path": "/nix/store/yb4bvacvpx4k6yasm22d7qvcy0gyfcy0-bats-1.12.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/az8pn6fcgrf8lv7kv7jdjyghbfn9z15r-bats-1.11.1"
+          "store_path": "/nix/store/yb4bvacvpx4k6yasm22d7qvcy0gyfcy0-bats-1.12.0"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,8 +2,8 @@
   "lockfile_version": "1",
   "packages": {
     "bats@1.11.1": {
-      "last_modified": "2025-05-19T23:16:24Z",
-      "resolved": "github:NixOS/nixpkgs/359c442b7d1f6229c1dc978116d32d6c07fe8440#bats",
+      "last_modified": "2025-06-20T02:24:11Z",
+      "resolved": "github:NixOS/nixpkgs/076e8c6678d8c54204abcb4b1b14c366835a58bb#bats",
       "source": "devbox-search",
       "version": "1.11.1",
       "systems": {
@@ -11,47 +11,47 @@
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ffaqbcz3lx4hv70cpl3zw8905asf0wk0-bats-1.11.1",
+              "path": "/nix/store/whjif7jimfg5kzydsjr80r4a3xwrvzl8-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ffaqbcz3lx4hv70cpl3zw8905asf0wk0-bats-1.11.1"
+          "store_path": "/nix/store/whjif7jimfg5kzydsjr80r4a3xwrvzl8-bats-1.11.1"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rmrd2ix70l5dfyl8y0fqlc81577k16mh-bats-1.11.1",
+              "path": "/nix/store/sga64j8wgf0wwpn1xggr2hc0ijsgyvlk-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/rmrd2ix70l5dfyl8y0fqlc81577k16mh-bats-1.11.1"
+          "store_path": "/nix/store/sga64j8wgf0wwpn1xggr2hc0ijsgyvlk-bats-1.11.1"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/dshgcgrx60nwam2wcmnbfq597vcp6j68-bats-1.11.1",
+              "path": "/nix/store/07h34ynvlcryaqcg4bjdgcs6qjd1f1py-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/dshgcgrx60nwam2wcmnbfq597vcp6j68-bats-1.11.1"
+          "store_path": "/nix/store/07h34ynvlcryaqcg4bjdgcs6qjd1f1py-bats-1.11.1"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/pfm41aj6rik9223yd28g4z5vb0d6pkzk-bats-1.11.1",
+              "path": "/nix/store/az8pn6fcgrf8lv7kv7jdjyghbfn9z15r-bats-1.11.1",
               "default": true
             }
           ],
-          "store_path": "/nix/store/pfm41aj6rik9223yd28g4z5vb0d6pkzk-bats-1.11.1"
+          "store_path": "/nix/store/az8pn6fcgrf8lv7kv7jdjyghbfn9z15r-bats-1.11.1"
         }
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "last_modified": "2025-06-06T12:35:49Z",
-      "resolved": "github:NixOS/nixpkgs/a4ff0e3c64846abea89662bfbacf037ef4b34207?lastModified=1749213349&narHash=sha256-UAaWOyQhdp7nXzsbmLVC67fo%2BQetzoTm9hsPf9X3yr4%3D"
+      "last_modified": "2025-12-05T15:03:55Z",
+      "resolved": "github:NixOS/nixpkgs/a672be65651c80d3f592a89b3945466584a22069?lastModified=1764947035&narHash=sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx%2BJ2FfutM7T9w%3D"
     },
     "go@1.23.9": {
       "last_modified": "2025-05-16T20:19:48Z",
@@ -198,8 +198,8 @@
       }
     },
     "shellcheck@0.10.0": {
-      "last_modified": "2025-05-16T20:19:48Z",
-      "resolved": "github:NixOS/nixpkgs/12a55407652e04dcf2309436eb06fef0d3713ef3#shellcheck",
+      "last_modified": "2025-09-18T16:33:27Z",
+      "resolved": "github:NixOS/nixpkgs/f4b140d5b253f5e2a1ff4e5506edbf8267724bde#shellcheck",
       "source": "devbox-search",
       "version": "0.10.0",
       "systems": {
@@ -207,97 +207,97 @@
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/4l7lf05gw9l0l84sssaxkwqb6arkx652-shellcheck-0.10.0-bin",
+              "path": "/nix/store/dxppq6y4mb663r0li716pavrahwh9sws-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/f0fscjx6xa6kbczhav1bh0vq3w2pmwfn-shellcheck-0.10.0-man",
+              "path": "/nix/store/7lpymai82rrcps6z7zl4q5j69w3pp5ng-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/mwahkil7jkc2y4y0q3myrkicp366vb82-shellcheck-0.10.0-doc",
+              "path": "/nix/store/0wbb09lk7bx9ywc453a8nnw41hc8qp1i-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/fbj9729m17pdvlinsdqxnd8ddl4iirzm-shellcheck-0.10.0"
+              "path": "/nix/store/ffxba7sh87j0vg759cjm7qmcadsmbfw7-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/4l7lf05gw9l0l84sssaxkwqb6arkx652-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/dxppq6y4mb663r0li716pavrahwh9sws-shellcheck-0.10.0-bin"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/irlalbizkr3bn83g1drmi4p4h4dx16i6-shellcheck-0.10.0-bin",
+              "path": "/nix/store/kvhcnjzmjyqc641yd57f7g26nraw64sm-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/zfpypv8l8py55rifk9yhzcis13z4sc5k-shellcheck-0.10.0-man",
+              "path": "/nix/store/2ps0gaalsjfvd6vh0zhq2l4d6xgrma8l-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/c3s6fpb28bfm02vbpi9cvxpxyymzmx9n-shellcheck-0.10.0-doc",
+              "path": "/nix/store/vn7d2fwlkjgq6hy3c7gjcypg3slkf592-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/6lgybvih5m2qinh419qzn52q6k4fwf4m-shellcheck-0.10.0"
+              "path": "/nix/store/dxqnpdj372kh001d84dg29l6l3aflrc0-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/irlalbizkr3bn83g1drmi4p4h4dx16i6-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/kvhcnjzmjyqc641yd57f7g26nraw64sm-shellcheck-0.10.0-bin"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/z8v7j4xkwswrx5vc05cfn9yp9sbxfkd2-shellcheck-0.10.0-bin",
+              "path": "/nix/store/ri8byd60sb58xqf3m0bli53xflx9n4l4-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/q88aiz7agllcjb8zflwlh23fm2wh431f-shellcheck-0.10.0-man",
+              "path": "/nix/store/0an459l9ajzapm9kinqh344xnlzp70fy-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/df107d185wg9kqc03aaq1fcyl2bknjnc-shellcheck-0.10.0-doc",
+              "path": "/nix/store/b1hcrb9c98w7cwqjc5wy5rrfx1gnw7lz-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/wz9qinlsaghahhj2bvlva9lgz3d8g07s-shellcheck-0.10.0"
+              "path": "/nix/store/5rfsd78v2il52xqvxmx15pp52zlds4al-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/z8v7j4xkwswrx5vc05cfn9yp9sbxfkd2-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/ri8byd60sb58xqf3m0bli53xflx9n4l4-shellcheck-0.10.0-bin"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "bin",
-              "path": "/nix/store/dw5aa0sf40aahg0fbwgfjwhjxnnrmipl-shellcheck-0.10.0-bin",
+              "path": "/nix/store/ayfrkdpk1sygzwwjqh19gcp5sfh557zd-shellcheck-0.10.0-bin",
               "default": true
             },
             {
               "name": "man",
-              "path": "/nix/store/6ksvcjrdzxn89ql0059g2hs0nmw0rf5v-shellcheck-0.10.0-man",
+              "path": "/nix/store/n8asflghb73ph65f2ixvr8hv6h7v9w0g-shellcheck-0.10.0-man",
               "default": true
             },
             {
               "name": "doc",
-              "path": "/nix/store/mfn1kxg9asp4nq4yrcr3niz5kfddaisf-shellcheck-0.10.0-doc",
+              "path": "/nix/store/wgb75fahwjf0h5gc7ww5zcvkhbm88sps-shellcheck-0.10.0-doc",
               "default": true
             },
             {
               "name": "out",
-              "path": "/nix/store/gxzk021q0f0h0jqwxiqikl1gkiih7qiq-shellcheck-0.10.0"
+              "path": "/nix/store/vh0ng4iyxch4lqmjmkbbjx8dw8xp569y-shellcheck-0.10.0"
             }
           ],
-          "store_path": "/nix/store/dw5aa0sf40aahg0fbwgfjwhjxnnrmipl-shellcheck-0.10.0-bin"
+          "store_path": "/nix/store/ayfrkdpk1sygzwwjqh19gcp5sfh557zd-shellcheck-0.10.0-bin"
         }
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.vallahaye.net/cpuset
 
-go 1.23
+go 1.24

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package cpuset
 
-const Version = "0.2.4"
+const Version = "0.3.0"


### PR DESCRIPTION
**Chores:**

- **deps:** bump devbox from 0.14.2 to 0.16.0 (#32)
- **deps:** bump go from 1.23.9 to 1.24.11 (#32)
- **deps:** bump goreleaser from 2.9.0 to 2.13.0 (#32)
- **deps:** bump golangci-lint from 1.64.8 to 2.6.2 (#32)
- **deps:** bump bats from 1.11.1 to 1.12.0 (#32)
- **deps:** bump shellcheck from 0.10.0 to 0.11.0 (#32)
